### PR TITLE
Import ast from smart instead of default export of @babel/template

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import template from '@babel/template';
+import { smart as template } from '@babel/template';
 import type { PluginObj, NodePath } from '@babel/core';
 import type { Statement, MemberExpression } from '@babel/types';
 


### PR DESCRIPTION
Based on https://github.com/javiertury/babel-plugin-transform-import-meta/issues/3, I tried to find a way to fix this.

As `ast` is really just `smart.ast` (see: https://github.com/babel/babel/blob/main/packages/babel-template/src/index.ts), the small change in this PR seems to fix this :thinking: 

Closes https://github.com/javiertury/babel-plugin-transform-import-meta/issues/3