### PR TITLE
feat: add support for additional meta apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,55 @@
 # babel-plugin-transform-import-meta
 
-Transforms import.meta for nodejs environments. This plugin replaces any occurrence of `import.meta.url`.
+Transforms `import.meta` for nodejs environments. This plugin supports transforming the following apis:
+
+- `import.meta.dirname`
+- `import.meta.filename`
+- `import.meta.resolve(specifier)`
+- `import.meta.url`
+
+## `import.meta.dirname`
+
+```js
+console.log(import.meta.dirname);
+```
+
+Is replaced with
+
+```js
+console.log(__dirname);
+```
+
+## `import.meta.filename`
+
+```js
+console.log(import.meta.filename);
+```
+
+Is replaced with
+
+```js
+console.log(__filename);
+```
+
+## `import.meta.resolve(specifier)`
+
+```js
+console.log(import.meta.resolve(myCustomFunction('path', 'file')));
+```
+
+Is replaced with
+
+```js
+console.log(require('url').pathToFileURL(require.resolve(myCustomFunction('path', 'file'))).toString());
+```
+
+## `import.meta.url`
 
 ```js
 console.log(import.meta.url);
 ```
 
-With this
+Is replaced with
 
 ```js
 console.log(require('url').pathToFileURL(__filename).toString());
@@ -16,7 +59,7 @@ console.log(require('url').pathToFileURL(__filename).toString());
 
 Install this package
 
-```javascript
+```sh
 npm install --save-dev babel-plugin-transform-import-meta
 ```
 
@@ -30,9 +73,9 @@ and add it to your babel plugins in `babel.config.json`
 }
 ```
 
-# Settings
+## Settings
 
-## ES6 modules
+### ES6 modules
 
 It's possible to use ES6 modules for the output. Useful to delegate module transformation to other plugins.
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -68,6 +68,51 @@ describe('babel-plugin-import-meta', () => {
       expect(result.trim()).toEqual(expected.trim());
     });
 
+    test('transforms import.meta.filename', () => {
+      const input = dedent(`
+        console.log(import.meta.filename);
+      `);
+
+      const expected = dedent(`
+        console.log(__filename);
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.dirname', () => {
+      const input = dedent(`
+        console.log(import.meta.dirname);
+      `);
+
+      const expected = dedent(`
+        console.log(__dirname);
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.resolve', () => {
+      const input = dedent(`
+        console.log(import.meta.resolve(myCustomFunction('path', 'file')));
+      `);
+
+      const expected = dedent(`
+        console.log(require('url').pathToFileURL(require.resolve(myCustomFunction('path', 'file'))).toString());
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
     unknownKeysSpec(pluginOptions);
   });
 
@@ -103,6 +148,53 @@ describe('babel-plugin-import-meta', () => {
         import path from 'path';
         console.log('foo');
         console.log(url.pathToFileURL(__filename).toString());
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.filename', () => {
+      const input = dedent(`
+        console.log(import.meta.filename);
+      `);
+
+      const expected = dedent(`
+        console.log(__filename);
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.dirname', () => {
+      const input = dedent(`
+        console.log(import.meta.dirname);
+      `);
+
+      const expected = dedent(`
+        console.log(__dirname);
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.resolve', () => {
+      const input = dedent(`
+        console.log(import.meta.resolve(myCustomFunction('path', 'file')));
+      `);
+
+      const expected = dedent(`
+        import { createRequire } from 'module';
+        import url from 'url';
+        console.log(url.pathToFileURL(createRequire(url.pathToFileURL(__filename).toString()).resolve(myCustomFunction('path', 'file'))).toString());
       `);
       const result = babelCore.transform(input, {
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,6 +50,17 @@ const unknownKeysSpec = (
 };
 
 describe('babel-plugin-import-meta', () => {
+  test('throws when target is invalid', () => {
+    const input = dedent(`
+      console.log(import.meta.url);
+    `);
+
+    expect(() => babelCore.transform(input, {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      plugins: [[importMetaPlugin, { module: 'no-module' }]]
+    })).toThrow('Invalid target, must be one of: "CommonJS" or "ES6"');
+  });
+
   describe('ES5', () => {
     const pluginOptions: PluginOptions | undefined = undefined;
 
@@ -98,9 +109,24 @@ describe('babel-plugin-import-meta', () => {
       expect(result.trim()).toEqual(expected.trim());
     });
 
-    test('transforms import.meta.resolve', () => {
+    test('transforms import.meta.resolve()', () => {
       const input = dedent(`
         console.log(import.meta.resolve(myCustomFunction('path', 'file')));
+      `);
+
+      const expected = dedent(`
+        console.log(require('url').pathToFileURL(require.resolve(myCustomFunction('path', 'file'))).toString());
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.resolve?.()', () => {
+      const input = dedent(`
+        console.log(import.meta.resolve?.(myCustomFunction('path', 'file')));
       `);
 
       const expected = dedent(`
@@ -135,7 +161,7 @@ describe('babel-plugin-import-meta', () => {
       expect(result.trim()).toEqual(expected.trim());
     });
 
-    test('injects import at the top of the file', () => {
+    test('injects import at the top of the file (import.meta.url)', () => {
       const input = dedent(`
         import path from 'path';
 
@@ -186,7 +212,7 @@ describe('babel-plugin-import-meta', () => {
       expect(result.trim()).toEqual(expected.trim());
     });
 
-    test('transforms import.meta.resolve', () => {
+    test('transforms import.meta.resolve()', () => {
       const input = dedent(`
         console.log(import.meta.resolve(myCustomFunction('path', 'file')));
       `);
@@ -195,6 +221,89 @@ describe('babel-plugin-import-meta', () => {
         import { createRequire } from 'module';
         import url from 'url';
         console.log(url.pathToFileURL(createRequire(url.pathToFileURL(__filename).toString()).resolve(myCustomFunction('path', 'file'))).toString());
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.resolve?.()', () => {
+      const input = dedent(`
+        console.log(import.meta.resolve?.(myCustomFunction('path', 'file')));
+      `);
+
+      const expected = dedent(`
+        import { createRequire } from 'module';
+        import url from 'url';
+        console.log(url.pathToFileURL(createRequire(url.pathToFileURL(__filename).toString()).resolve(myCustomFunction('path', 'file'))).toString());
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('injects import at the top of the file (import.meta.resolve())', () => {
+      const input = dedent(`
+        import path from 'path';
+
+        console.log(import.meta.resolve(myCustomFunction('path', 'file')));
+      `);
+
+      const expected = dedent(`
+        import { createRequire } from 'module';
+        import url from 'url';
+        import path from 'path';
+        console.log(url.pathToFileURL(createRequire(url.pathToFileURL(__filename).toString()).resolve(myCustomFunction('path', 'file'))).toString());
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('injects import at the top of the file (import.meta.resolve?.())', () => {
+      const input = dedent(`
+        import path from 'path';
+
+        console.log(import.meta.resolve?.(myCustomFunction('path', 'file')));
+      `);
+
+      const expected = dedent(`
+        import { createRequire } from 'module';
+        import url from 'url';
+        import path from 'path';
+        console.log(url.pathToFileURL(createRequire(url.pathToFileURL(__filename).toString()).resolve(myCustomFunction('path', 'file'))).toString());
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('uses unique import names, when url and createRequire are already defined', () => {
+      const input = dedent(`
+        import path from 'path';
+
+        const url = '123';
+        const createRequire = () => {};
+        console.log(import.meta.resolve(myCustomFunction('path', 'file')));
+      `);
+
+      const expected = dedent(`
+        import { createRequire as _createRequire } from 'module';
+        import _url from 'url';
+        import path from 'path';
+        const url = '123';
+
+        const createRequire = () => {};
+
+        console.log(_url.pathToFileURL(_createRequire(_url.pathToFileURL(__filename).toString()).resolve(myCustomFunction('path', 'file'))).toString());
       `);
       const result = babelCore.transform(input, {
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { smart } from '@babel/template';
 import type { PluginObj, NodePath } from '@babel/core';
-import type { Statement, MemberExpression } from '@babel/types';
+import type { Statement, MemberExpression, CallExpression, OptionalCallExpression, ArgumentPlaceholder, JSXNamespacedName, SpreadElement, Expression } from '@babel/types';
 
 export interface PluginOptions {
   module?: 'CommonJS' | 'ES6' | undefined
@@ -28,8 +28,13 @@ export default function (): PluginObj {
         if (target !== 'CommonJS' && target !== 'ES6') {
           throw new Error('Invalid target, must be one of: "CommonJS" or "ES6"');
         }
-        const metas: Array<NodePath<MemberExpression>> = [];
-        const identifiers = new Set<string>();
+        const urlMetas: Array<NodePath<MemberExpression>> = [];
+        const filenameMetas: Array<NodePath<MemberExpression>> = [];
+        const dirnameMetas: Array<NodePath<MemberExpression>> = [];
+        const resolveMetas: Array<NodePath<CallExpression> | NodePath<OptionalCallExpression>> = [];
+
+        const urlScopeIdentifiers = new Set<string>();
+        const resolveScopeIdentifiers = new Set<string>();
 
         path.traverse({
           MemberExpression (memberExpPath) {
@@ -42,40 +47,120 @@ export default function (): PluginObj {
               node.property.type === 'Identifier' &&
               node.property.name === 'url'
             ) {
-              metas.push(memberExpPath);
+              urlMetas.push(memberExpPath);
               for (const name of Object.keys(memberExpPath.scope.getAllBindings())) {
-                identifiers.add(name);
+                urlScopeIdentifiers.add(name);
+              }
+            }
+
+            if (
+              node.object.type === 'MetaProperty' &&
+              node.object.meta.name === 'import' &&
+              node.object.property.name === 'meta' &&
+              node.property.type === 'Identifier' &&
+              node.property.name === 'filename'
+            ) {
+              filenameMetas.push(memberExpPath);
+            }
+
+            if (
+              node.object.type === 'MetaProperty' &&
+              node.object.meta.name === 'import' &&
+              node.object.property.name === 'meta' &&
+              node.property.type === 'Identifier' &&
+              node.property.name === 'dirname'
+            ) {
+              dirnameMetas.push(memberExpPath);
+            }
+          },
+          CallExpression (callExpPath) {
+            const { node } = callExpPath;
+
+            if (
+              node.type === 'CallExpression' &&
+              node.callee.type === 'MemberExpression' &&
+              node.callee.object.type === 'MetaProperty' &&
+              node.callee.object.meta.name === 'import' &&
+              node.callee.object.property.name === 'meta' &&
+              node.callee.property.type === 'Identifier' &&
+              node.callee.property.name === 'resolve'
+            ) {
+              resolveMetas.push(callExpPath);
+              for (const name of Object.keys(callExpPath.scope.getAllBindings())) {
+                resolveScopeIdentifiers.add(name);
+              }
+            }
+          },
+          OptionalCallExpression (callExpPath) {
+            const { node } = callExpPath;
+
+            if (
+              node.type === 'OptionalCallExpression' &&
+              node.callee.type === 'MemberExpression' &&
+              node.callee.object.type === 'MetaProperty' &&
+              node.callee.object.meta.name === 'import' &&
+              node.callee.object.property.name === 'meta' &&
+              node.callee.property.type === 'Identifier' &&
+              node.callee.property.name === 'resolve'
+            ) {
+              resolveMetas.push(callExpPath);
+              for (const name of Object.keys(callExpPath.scope.getAllBindings())) {
+                resolveScopeIdentifiers.add(name);
               }
             }
           }
         });
 
-        if (metas.length === 0) {
-          return;
-        }
+        if ((urlMetas.length !== 0) || (resolveMetas.length !== 0)) {
+          let metaUrlReplacement: Statement;
+          let metaResolveReplacement: ((args: Array<ArgumentPlaceholder | JSXNamespacedName | SpreadElement | Expression>) => Statement);
 
-        let metaUrlReplacement: Statement;
-
-        switch (target) {
-          case 'CommonJS': {
-            metaUrlReplacement = smart.ast`require('url').pathToFileURL(__filename).toString()` as Statement;
-            break;
-          }
-          case 'ES6': {
-            let urlId = 'url';
-
-            while (identifiers.has(urlId)) {
-              urlId = path.scope.generateUidIdentifier('url').name;
+          switch (target) {
+            case 'CommonJS': {
+              metaUrlReplacement = smart.ast`require('url').pathToFileURL(__filename).toString()` as Statement;
+              metaResolveReplacement = (args) => smart.ast`require('url').pathToFileURL(require.resolve(${args})).toString()` as Statement;
+              break;
             }
+            case 'ES6': {
+              let urlId = 'url';
+              let createRequireId = 'createRequire';
 
-            path.node.body.unshift(smart.ast`import ${urlId} from 'url';` as Statement);
-            metaUrlReplacement = smart.ast`${urlId}.pathToFileURL(__filename).toString()` as Statement;
-            break;
+              while (urlScopeIdentifiers.has(urlId) || resolveScopeIdentifiers.has(urlId)) {
+                urlId = path.scope.generateUidIdentifier('url').name;
+              }
+
+              while (resolveScopeIdentifiers.has(createRequireId)) {
+                createRequireId = path.scope.generateUidIdentifier('createRequire').name;
+              }
+
+              path.node.body.unshift(smart.ast`import ${urlId} from 'url';` as Statement);
+              if (resolveMetas.length !== 0) {
+                path.node.body.unshift(smart.ast`import { createRequire as ${createRequireId} } from 'module';` as Statement);
+              }
+              metaUrlReplacement = smart.ast`${urlId}.pathToFileURL(__filename).toString()` as Statement;
+              metaResolveReplacement = (args) => smart.ast`${urlId}.pathToFileURL(createRequire(${urlId}.pathToFileURL(__filename).toString()).resolve(${args})).toString()` as Statement;
+              break;
+            }
+          }
+
+          for (const meta of urlMetas) {
+            meta.replaceWith(metaUrlReplacement);
+          }
+
+          for (const meta of resolveMetas) {
+            meta.replaceWith(metaResolveReplacement(meta.node.arguments));
           }
         }
 
-        for (const meta of metas) {
-          meta.replaceWith(metaUrlReplacement);
+        const metaFilenameReplacement: Statement = smart.ast`__filename` as Statement;
+        const metaDirnameReplacement: Statement = smart.ast`__dirname` as Statement;
+
+        for (const meta of filenameMetas) {
+          meta.replaceWith(metaFilenameReplacement);
+        }
+
+        for (const meta of dirnameMetas) {
+          meta.replaceWith(metaDirnameReplacement);
         }
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export default function (): PluginObj {
         const urlScopeIdentifiers = new Set<string>();
         const resolveScopeIdentifiers = new Set<string>();
 
+        // Gather all of the relevant data for import.meta's that we're going to replace later.
         path.traverse({
           MemberExpression (memberExpPath) {
             const { node } = memberExpPath;
@@ -111,6 +112,7 @@ export default function (): PluginObj {
           }
         });
 
+        // For url and resolve, we'll potentially need to add imports, depending on the target.
         if ((urlMetas.length !== 0) || (resolveMetas.length !== 0)) {
           let metaUrlReplacement: Statement;
           let metaResolveReplacement: ((args: Array<ArgumentPlaceholder | JSXNamespacedName | SpreadElement | Expression>) => Statement);
@@ -138,7 +140,7 @@ export default function (): PluginObj {
                 path.node.body.unshift(smart.ast`import { createRequire as ${createRequireId} } from 'module';` as Statement);
               }
               metaUrlReplacement = smart.ast`${urlId}.pathToFileURL(__filename).toString()` as Statement;
-              metaResolveReplacement = (args) => smart.ast`${urlId}.pathToFileURL(createRequire(${urlId}.pathToFileURL(__filename).toString()).resolve(${args})).toString()` as Statement;
+              metaResolveReplacement = (args) => smart.ast`${urlId}.pathToFileURL(${createRequireId}(${urlId}.pathToFileURL(__filename).toString()).resolve(${args})).toString()` as Statement;
               break;
             }
           }


### PR DESCRIPTION
This change adds support for the following import.meta apis:

- import.meta.dirname
- import.meta.filename
- import.meta.resolve(specifier)

Confirmed the following:
Output matches behavior defined here: https://nodejs.org/api/esm.html#importmetadirname
Code works in my project using `import.meta.dirname`

I also increased test coverage to 100%

Closes #16 