### PR TITLE
Clarify which BSD license is used (BSD-3-Clause)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/javiertury/babel-plugin-transform-import-meta"
   },
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "author": "Javier Garcia <javiertury@gmail.com>",
   "keywords": [
     "babel-plugin",


### PR DESCRIPTION
`BSD` is not a valid [SPDX identifier](https://spdx.org/licenses/), so it trips up our tooling which checks dependencies for allowed licenses. :)

It appears that this project uses [the 3-Clause BSD license](https://opensource.org/license/bsd-3-clause), so I updated the `license` field accordingly.