### PR TITLE
feat: transform import.meta.env to an empty object expression

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -139,6 +139,36 @@ describe('babel-plugin-import-meta', () => {
       expect(result.trim()).toEqual(expected.trim());
     });
 
+    test('transforms import.meta.env', () => {
+      const input = dedent(`
+        console.log(import.meta.env ? import.meta.env.MODE : 'none');
+      `);
+
+      const expected = dedent(`
+        console.log(({}) ? ({}).MODE : 'none');
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- comfort shortcut
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.env?.key', () => {
+      const input = dedent(`
+        console.log(import.meta.env?.MODE);
+      `);
+
+      const expected = dedent(`
+        console.log(({})?.MODE);
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- comfort shortcut
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
     unknownKeysSpec(pluginOptions);
   });
 
@@ -238,6 +268,36 @@ describe('babel-plugin-import-meta', () => {
         import { createRequire } from 'module';
         import url from 'url';
         console.log(url.pathToFileURL(createRequire(url.pathToFileURL(__filename).toString()).resolve(myCustomFunction('path', 'file'))).toString());
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- comfort shortcut
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.env', () => {
+      const input = dedent(`
+        console.log(import.meta.env ? import.meta.env.MODE : 'none');
+      `);
+
+      const expected = dedent(`
+        console.log(({}) ? ({}).MODE : 'none');
+      `);
+      const result = babelCore.transform(input, {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- comfort shortcut
+        plugins: [pluginOptions ? [importMetaPlugin, pluginOptions] : importMetaPlugin]
+      })?.code ?? '';
+      expect(result.trim()).toEqual(expected.trim());
+    });
+
+    test('transforms import.meta.env?.key', () => {
+      const input = dedent(`
+        console.log(import.meta.env?.MODE);
+      `);
+
+      const expected = dedent(`
+        console.log(({})?.MODE);
       `);
       const result = babelCore.transform(input, {
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions -- comfort shortcut


### PR DESCRIPTION
## Description

This PR adds support for transforming `import.meta.env` into an empty parenthesized object literal `({})`. The object literal needs to be parenthesized so that `import.meta.env?.MODE` becomes `({})?.mode` rather than `{}?.mode` which is invalid syntax.

I opted for this rather than `undefined`, because that might produce code such as `undefined.MODE` which is guaranteed to fail at runtime. It might be worth arguing that code should be safely doing `import.meta.env ? import.meta.env.MODE : …` but that can't be guaranteed.

The `env` object is empty because I don't know if there is anything immediately useful to put into it. The [Vite documentation](https://vite.dev/guide/env-and-mode) mentions several things, but it might be better to accept an `env` option to this plugin's config and let users's build their own `env`. I kept my PR as small as I could, so I didn't add that.
 
## Motivation

In Zustand and Jotai, they use `import.meta.env`, which does not [seem to be standard behaviour](https://nodejs.org/docs/latest/api/esm.html#importmeta), and is not transformed by this plugin. [reference](https://github.com/pmndrs/zustand/blob/17e281fd75a8200e3598658e732b8b4a3055f0b1/rollup.config.mjs#L56-L63)

As a result, using Zustand or Jotai from React Native is problematic since `import.meta` is not currently supported by React Native's bundler Metro. [discussion](https://github.com/pmndrs/zustand/discussions/1967)

If this plugin transformed `import.meta.env` those modules could be imported without needing to patch them.